### PR TITLE
Add support for using preprocessor for declarations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version "1.8.0"
-    id 'org.jetbrains.intellij' version "1.13.3"
+    id 'org.jetbrains.intellij' version "1.17.0"
     id "org.jetbrains.grammarkit" version "2022.3"
     id 'org.jetbrains.changelog' version "1.3.1"
     id 'java'

--- a/grammar/GlslGrammar.bnf
+++ b/grammar/GlslGrammar.bnf
@@ -527,7 +527,7 @@
         INTCONSTANT="regexp:0x[\da-fA-F]+|\d+"
         BOOLCONSTANT="regexp:false|true"
         STRING_LITERAL="regexp:(\"([^\"\\]|\[.])*\")"
-        IDENTIFIER="regexp:[a-zA-Z_]+\w*"
+        IDENTIFIER="regexp:[a-zA-Z_]+\w*(##\w*[a-zA-Z_]+\w*)*"
     ]
 }
 
@@ -1162,6 +1162,7 @@ pp_statement
     |    pp_version_declaration PP_END
     |    pp_extension PP_END
     |    pp_line PP_END
+    |    pp_function_call
     |    macro_literal INTCONSTANT PP_END
 
 private pp_extension
@@ -1203,7 +1204,7 @@ pp_single_declaration
     ::= variable_identifier expr?
 
 pp_define_function
-    ::= variable_identifier LEFT_PAREN pp_define_params RIGHT_PAREN expr
+    ::= variable_identifier LEFT_PAREN pp_define_params RIGHT_PAREN (expr|declaration)
     {   pin=2 }
 
 private pp_define_params
@@ -1221,3 +1222,24 @@ macro_literal
     ::= MACRO_LINE
     |   MACRO_FILE
     |   MACRO_VERSION
+
+pp_function_call
+    ::= pp_function_call_header_with_parameters RIGHT_PAREN
+	|   pp_function_call_header_no_parameters RIGHT_PAREN
+
+private pp_function_call_header_no_parameters
+    ::= pp_function_call_header
+
+private pp_recover_function_call_header_with_parameters ::= !(RIGHT_PAREN)
+
+private pp_function_call_header_with_parameters
+    ::= pp_function_call_header pp_function_arg (COMMA pp_function_arg)*
+    {   recoverWhile=pp_recover_function_call_header_with_parameters   }
+
+private pp_function_arg
+    ::= expr_no_assignment
+    |   type_specifier
+    |   LEFT_BRACE struct_declaration_list RIGHT_BRACE
+
+private pp_function_call_header
+    ::= variable_identifier LEFT_PAREN

--- a/grammar/GlslLexer.flex
+++ b/grammar/GlslLexer.flex
@@ -50,7 +50,7 @@ DOUBLECONSTANT=({FRACTIONAL}|{FRACTIONAL2}){FLOATING_SUFFIX_DOUBLE}?
 
 BOOLCONSTANT=false|true
 STRING_LITERAL=(\"([^\"\\]|\\.)*\")
-IDENTIFIER=[a-zA-Z_]+\w*
+IDENTIFIER=[a-zA-Z_]+\w*(##\w*[a-zA-Z_]+\w*)*
 PP_VERSION="#version"
 PP_DEFINE="#define"
 PP_UNDEF="#undef"


### PR DESCRIPTION
Example:
```glsl
#define BINDLESS_SET 1
#define BINDLESS_TEX_BINDING 0
#define BINDLESS_TEX_COUNT 1024
#define BINDLESS_TEX(ty, name) \
    layout (set = BINDLESS_SET, binding = BINDLESS_TEX_BINDING) \
    uniform ty name[BINDLESS_TEX_COUNT];

BINDLESS_TEX(sampler2D, u_global_textures)
```

It is still very limited, but is better than nothing :)

P.S. Alternatively it can be done like this (full support, but no highlighting):
https://github.com/walt-grace/glsl-plugin-idea/compare/main...Rexagon:glsl-plugin-idea:feature/pp_text
